### PR TITLE
Bump lib to add support for macOS 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build
         run: |
-          ./scripts/download-openpnp-capture.sh v0.0.22
+          ./scripts/download-openpnp-capture.sh v0.0.23
           mvn -B clean package
 
       - name: Upload Artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openpnp</groupId>
 	<artifactId>openpnp-capture-java</artifactId>
-	<version>0.0.22</version>
+	<version>0.0.23</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
v0.0.23 has support for macOS 12 (Monterey) : https://github.com/openpnp/openpnp-capture/pull/55

on v0.0.22 camera settings are greyed out:

<img width="1683" alt="Screenshot of OpenPnP (02-07-2022, 10-59-54)" src="https://user-images.githubusercontent.com/1329094/182861755-01d6bc96-8560-4704-b929-2766fed83255.png">

If approved and merged will create a PR to bump openpnp-capture-java in openpnp

v0.0.23 has been tested locally on macOS 12 and works as expected:

<img width="827" alt="Screenshot of OpenPnP (04-08-2022, 14-43-09)" src="https://user-images.githubusercontent.com/1329094/182862087-e5b273d4-bf2f-4906-bc92-ec17e8c3ae17.png">

