### PR TITLE
Fix warning on unnecessary double load of openpnp-capture library

### DIFF
--- a/src/main/java/org/openpnp/capture/library/OpenpnpCaptureLibrary.java
+++ b/src/main/java/org/openpnp/capture/library/OpenpnpCaptureLibrary.java
@@ -15,7 +15,7 @@ import java.nio.IntBuffer;
  */
 public interface OpenpnpCaptureLibrary extends Library {
 	public static final String JNA_LIBRARY_NAME = "openpnp-capture";
-	public static final NativeLibrary JNA_NATIVE_LIB = NativeLibrary.getInstance(OpenpnpCaptureLibrary.JNA_LIBRARY_NAME);
+	//public static final NativeLibrary JNA_NATIVE_LIB = NativeLibrary.getInstance(OpenpnpCaptureLibrary.JNA_LIBRARY_NAME);
 	//public static final OpenpnpCaptureLibrary INSTANCE = (OpenpnpCaptureLibrary) Native.loadLibrary(OpenpnpCaptureLibrary.JNA_LIBRARY_NAME, OpenpnpCaptureLibrary.class);
 	public static final OpenpnpCaptureLibrary INSTANCE = Native.load(OpenpnpCaptureLibrary.JNA_LIBRARY_NAME, OpenpnpCaptureLibrary.class);
 	/** <i>native declaration : /Users/romanvg/dev/openpnp-capture/include/openpnp-capture.h</i> */


### PR DESCRIPTION
Currently, the JNAeator generated code loads the `openpnp-capture` twice, leading to the following warning:
```
Class PlatformAVCaptureDelegate is implemented in both ../Library/Caches/JNA/temp/jna10042956694623537098.tmp (0x14b6ac5f8) and ../Library/Caches/JNA/temp/jna8716218045893292183.tmp (0x14b7345f8). One of the two will be used. Which one is undefined.
```

The warning is harmless but unncessary, since `Native.load` calls `NativeLibrary.getInstance` anyway and `JNA_NATIVE_LIB` is never referenced. This PR comments out one of the load directives to remove the warning.